### PR TITLE
Add additional audio file types & improve metadata

### DIFF
--- a/audio-player/package.json
+++ b/audio-player/package.json
@@ -88,7 +88,8 @@
   },
   "dependencies": {
     "material-flux": "^1.4.0",
-    "musicmetadata": "^2.0.5",
+    "mime-types": "^2.1.18",
+    "music-metadata": "^2.3.2",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",

--- a/audio-player/src/assets/index.html
+++ b/audio-player/src/assets/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self';" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; media-src 'self' filesystem:" />
   <title>Electron Audio Player</title>
   <link rel="stylesheet" href="./bundle.css">
   <script src="./renderer.js"></script>

--- a/audio-player/src/js/renderer/main/model/MusicImporter.js
+++ b/audio-player/src/js/renderer/main/model/MusicImporter.js
@@ -79,7 +79,7 @@ export default class MusicImporter {
     this._ipc.send(IPCKeys.RequestShowOpenDialog, {
       title: 'Select music files',
       filters: [
-        {name: 'Musics', extensions: ['mp3', 'm4a', 'aac', 'wav']}
+        {name: 'Musics', extensions: ['mp3', 'mp2', 'm2a', 'm4a', 'aac', 'wav', 'wma', 'flac', 'opus', 'ogg']}
       ],
       properties: ['openFile', 'multiSelections']
     })


### PR DESCRIPTION
Allow additional music-files to be added: 'mp2', 'm2a', 'aac', 'wma', 'flac', 'opus', 'ogg'
Improve music-metadata, replaced deprecated dependency with [successor](https://github.com/Borewit/music-metadata).
